### PR TITLE
feat: Add ability to pass conversion timeout flag to unoserver

### DIFF
--- a/build-context/entrypoint.sh
+++ b/build-context/entrypoint.sh
@@ -14,12 +14,15 @@ export PS1='\u@\h:\w\$ '
 
 echo "using: $(libreoffice --version)"
 
+# sanity parameters for unoserver
+export UNOSERVER_CONVERSION_TIMEOUT=${UNOSERVER_CONVERSION_TIMEOUT:-5}
+
 # if tty then assume that container is interactive
 if [ ! -t 0 ]; then
     echo "Running unoserver-docker in non-interactive."
     echo "For interactive mode use '-it', e.g. 'docker run -v /tmp:/data -it unoserver/unoserver-docker'."
 
-    unoserver --interface 0.0.0.0
+    unoserver --interface 0.0.0.0 --conversion-timeout ${UNOSERVER_CONVERSION_TIMEOUT}
     # # run supervisord in foreground
     # supervisord -c "$SUPERVISOR_NON_INTERACTIVE_CONF"
 else
@@ -35,7 +38,7 @@ else
 
     # wait until unoserver started and listens on port 2002.
     wait_for_unoserver
-    
+
     # if commands have been passed to container run them and exit, else start bash
     if [[ $# -gt 0 ]]; then
         eval "$@"

--- a/build-context/supervisor/conf/interactive/supervisord.conf
+++ b/build-context/supervisor/conf/interactive/supervisord.conf
@@ -3,7 +3,7 @@ pidfile = /var/run/supervisord.pid
 
 # Note that at log level debug, the supervisord log file will record the stderr/stdout output
 # of its child processes and extended info info about process state changes,
-# which is useful for debugging a process which isn’t starting properly. 
+# which is useful for debugging a process which isn’t starting properly.
 # and also makes it available using `docker logs [container]`
 #logfile = /var/log/supervisor/supervisord.log
 logfile = /dev/stdout
@@ -30,8 +30,8 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl = unix:///var/run/supervisor.sock
 
 [program:unoserver]
-command = unoserver
-#stdout_logfile = /var/log/supervisor/%(program_name)s.log 
+command = unoserver --conversion-timeout %(ENV_UNOSERVER_CONVERSION_TIMEOUT)s
+#stdout_logfile = /var/log/supervisor/%(program_name)s.log
 stdout_logfile = /dev/stdout
 stderr_logfile = /dev/stderr
 stdout_logfile_maxbytes = 0


### PR DESCRIPTION
This follows the discussion within #89 for testing purposes. Non-interactive mode "works" but interactive mode is untested.

This appears to successfully stop unoserver / libreoffice, but then I believe this causes issues with the client