### PR TITLE
build(deps): Bump Alpine to 3.23 and eclipse-temurin to JDK 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM eclipse-temurin:24.0.1_9-jdk-alpine-3.21
+FROM eclipse-temurin:25.0.2_10-jdk-alpine-3.23
 
 ARG BUILD_CONTEXT="build-context"
 ARG UID=worker
 ARG GID=worker
 # renovate: pypi: unoserver
-ARG VERSION_UNOSERVER=3.4
+ARG VERSION_UNOSERVER=3.6
 
 LABEL org.opencontainers.image.title="unoserver-docker"
 LABEL org.opencontainers.image.description="Container image that contains unoserver and libreoffice including large set of fonts for file format conversions"


### PR DESCRIPTION
## Summary

- Bump base image from `eclipse-temurin:24.0.1_9-jdk-alpine-3.21` to `eclipse-temurin:25.0.2_10-jdk-alpine-3.23`
- Bump unoserver from 3.4 to 3.6 (supersedes #105)

This upgrades LibreOffice from **7.6.7.2** to **25.8.1.1** and moves from JDK 24 (non-LTS) to JDK 25 (LTS).

## Changes

| Component | Before | After |
|-----------|--------|-------|
| Alpine | 3.21 | 3.23 (latest, EOL 2027-11) |
| LibreOffice | 7.6.7.2 | 25.8.1.1 |
| JDK | 24.0.1 (non-LTS) | 25.0.2 (LTS) |
| unoserver | 3.4 | 3.6 |

## Test plan

- [x] Image builds successfully (aarch64)
- [x] `libreoffice --version` reports 25.8.1.1
- [x] unoserver 3.6 starts and listens on port 2003
- [x] DOCX → PDF conversion verified with a real document